### PR TITLE
Make pipelines pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ COPY docker/php/prod/opcache.ini    $PHP_INI_DIR/conf.d/opcache.ini
 # copy file required by opcache preloading
 COPY config/preload.php /srv/open_marketplace/config/preload.php
 
+# Configure default timezone for PHP
+ENV PHP_DATE_TIMEZONE=UTC
+
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN set -eux; \

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -11,6 +11,10 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     $_ENV += $env;
 } elseif (!class_exists(Dotenv::class)) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
+
+    return;
 } else {
     // load all the .env files
     (new Dotenv(true))->loadEnv(dirname(__DIR__).'/.env');

--- a/config/packages/prod/doctrine.yaml
+++ b/config/packages/prod/doctrine.yaml
@@ -17,13 +17,15 @@ doctrine:
 
 services:
     doctrine.result_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
+        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
         arguments:
             - '@doctrine.result_cache_pool'
     doctrine.system_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
+        factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
         arguments:
             - '@doctrine.system_cache_pool'
 

--- a/config/packages/test_cached/doctrine.yaml
+++ b/config/packages/test_cached/doctrine.yaml
@@ -14,13 +14,15 @@ doctrine:
 
 services:
     doctrine.result_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
+        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
         arguments:
             - '@doctrine.result_cache_pool'
     doctrine.system_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
+        factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
         arguments:
             - '@doctrine.system_cache_pool'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
     level: 8
     reportUnmatchedIgnoredErrors: false
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
 
     excludePaths:
         # Makes PHPStan crash
@@ -13,5 +11,9 @@ parameters:
         - 'tests/Application/src/**.php'
 
     ignoreErrors:
+        -
+            identifier: missingType.iterableValue
+        -
+            identifier: missingType.generics
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
         - '/Cannot call method [a-z]+Node\(\) on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null\./'

--- a/src/Component/Core/Api/DataPersister/ConversationPersister.php
+++ b/src/Component/Core/Api/DataPersister/ConversationPersister.php
@@ -28,7 +28,7 @@ final class ConversationPersister implements DataPersisterInterface
         return $data instanceof ConversationInterface;
     }
 
-    public function persist($data): void
+    public function persist(mixed $data): void
     {
         $data->setShopUser($this->security->getUser());
 
@@ -36,7 +36,7 @@ final class ConversationPersister implements DataPersisterInterface
         $this->manager->flush();
     }
 
-    public function remove($data): void
+    public function remove(mixed $data): void
     {
         $this->manager->remove($data);
         $this->manager->flush();

--- a/src/Component/Core/Api/DataPersister/MessagePersister.php
+++ b/src/Component/Core/Api/DataPersister/MessagePersister.php
@@ -28,7 +28,7 @@ final class MessagePersister implements DataPersisterInterface
         return $data instanceof MessageInterface;
     }
 
-    public function persist($data): void
+    public function persist(mixed $data): void
     {
         $data->setShopUser($this->security->getUser());
 
@@ -36,7 +36,7 @@ final class MessagePersister implements DataPersisterInterface
         $this->manager->flush();
     }
 
-    public function remove($data): void
+    public function remove(mixed $data): void
     {
         $this->manager->remove($data);
         $this->manager->flush();

--- a/src/Component/Core/Shop/Resources/validation/ChannelPricing.xml
+++ b/src/Component/Core/Shop/Resources/validation/ChannelPricing.xml
@@ -9,7 +9,7 @@
             <constraint name="Range">
                 <option name="min">0.00</option>
                 <option name="max">1000000000</option>
-                <option name="minMessage">sylius.channel_pricing.price.min</option>
+                <option name="notInRangeMessage">sylius.channel_pricing.price.min</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>
@@ -17,7 +17,7 @@
             <constraint name="Range">
                 <option name="min">0.00</option>
                 <option name="max">1000000000</option>
-                <option name="minMessage">sylius.channel_pricing.price.min</option>
+                <option name="notInRangeMessage">sylius.channel_pricing.price.min</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>
@@ -25,7 +25,7 @@
             <constraint name="Range">
                 <option name="min">0.00</option>
                 <option name="max">1000000000</option>
-                <option name="minMessage">sylius.channel_pricing.price.min</option>
+                <option name="notInRangeMessage">sylius.channel_pricing.price.min</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>

--- a/tests/Integration/DataFixtures/ORM/SettlementRepositoryTest/test_it_finds_all_available_periods.yaml
+++ b/tests/Integration/DataFixtures/ORM/SettlementRepositoryTest/test_it_finds_all_available_periods.yaml
@@ -88,8 +88,8 @@ BitBag\OpenMarketplace\Component\Settlement\Entity\Settlement:
     vendor: '@vendor_bruce'
     total_amount: 100500
     total_commission_amount: 1029
-    start_date: '<date_create("first day of last month")>'
-    end_date: '<date_create("last day of last month")>'
+    start_date: '<date_create("first day of June")>'
+    end_date: '<date_create("last day of June")>'
     channel: '@channel_us'
   vendor_tommy_settlement_1:
     vendor: '@vendor_tommy'

--- a/tests/Integration/Repository/SettlementRepositoryTest.php
+++ b/tests/Integration/Repository/SettlementRepositoryTest.php
@@ -42,6 +42,7 @@ final class SettlementRepositoryTest extends JsonApiTestCase
         $period[] = $this->generatePeriod('last week monday', 'last week sunday');
         $period[] = $this->generatePeriod('first day of January', 'last day of January');
         $period[] = $this->generatePeriod('first day of April', 'last day of June');
+        $period[] = $this->generatePeriod('first day of June', 'last day of June');
 
         rsort($period);
 


### PR DESCRIPTION
The pipelines are currently failing due to PhpStan, and later, PhpUnit.

I also had trouble booting Docker Compose setup locally: first, PHP would complain about missing timezone value at image build time, and later, after I fixed that, `cache:clear` would fail because the `Range` constraint no longer allows passing `minMessage` or `maxMessage` when both `min` and `max` options are present. 

These changes should take care of all these issues. Interestingly, the `cache:clear` issue kept happening even after I modified `ChannelPricing.xml`, which I suppose was some cache issue. I ended up downgrading `symfony/` requirements to `^5.4` locally to overcome that.

Additionally, I modified an assertion made by a test that was failing. I have no idea if or why the test was previously passing. I didn't try to dig deep into the code, but it seems to me like it should have been failing all along since the fixtures define five settlements which span four periods, but the test expected three periods only. Unless... unless the that code was merged in February, in which case another two settlements had the same period, resulting in three periods in total. After some deliberation, I decided to replace `last month` with `June` in both the test and the fixture to make sure the assertions and the results of this test are always consistent.

Anyway, at least GitHub checks are now green, unlike in my other PRs, which is a good sign, I think! 